### PR TITLE
[W-10849454] Add flag to policy apply command

### DIFF
--- a/modules/ROOT/pages/_partials/api-mgr.adoc
+++ b/modules/ROOT/pages/_partials/api-mgr.adoc
@@ -489,7 +489,7 @@ For example, `api-mgr policy apply -c '{"property": "value"}'`
 
 | `--configFlag [file]`
 | Pass the configuration data as a file. +
-For example, `api-mgr policy apply -c ./config.json`
+For example, `api-mgr policy apply --configFile ./config.json`
 
 | `-p, --pointcut [dataJSON]`
 | Pass pointcut data as JSON strings. +


### PR DESCRIPTION
We are adding a new flag to `api-mgr policy apply` command.

This flag (`--configFile`) let the user send a JSON configuration via file to the CLI, instead of sending the JSON in the CLI, which could create some parsing errors.

[[W-10849454]](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000sy6jKYAQ/view)