### PR TITLE
incorrect example in optional CLI configuration

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -122,7 +122,7 @@ You can also pass this value using the environment variable `export ANYPOINT_ORG
 You can also pass this value using the environment variable `export ANYPOINT_ENV=<name>`.
 
 | `host` | The host of your Anypoint Platform Installation +
-By default, this value points to `\anypoint.mulesoft.com`. +
+By default, this value points to `anypoint.mulesoft.com`. +
 
 * If you are using Anypoint Platform PCE, pass the address where you are hosting the platform.
 * If you are using Anypoint Platform EU Cloud, pass your EU control plane URL.


### PR DESCRIPTION
The host parameter does not accept the protocol in the URL for the host parameter.

Gus ticket: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000vH6NpYAK/view