### PR TITLE
W-10717188 - update-docs - Exchange asset list does not support sort argument

### DIFF
--- a/modules/ROOT/pages/_partials/exchange-assets.adoc
+++ b/modules/ROOT/pages/_partials/exchange-assets.adoc
@@ -305,7 +305,6 @@ Besides the default `--help`, `-f`/`--fields` and `-o`/`--output` options, this 
 |Command | Description |  Example
 |`--limit` | Number of results to retrieve | `exchange asset list --limit 2`
 |`--offset` | Offsets the number of APIs passed | `exchange asset list --offset 3`
-|`--sort` | Sorts the results in the field name passed | `exchange asset list --sort "Latest Version"`
 |`--organizationId` | Filters by organization id | `exchange asset list --organizationId a12b3c45-de6f-789g-hi01-j2klm3nop4q5`
 |===
 


### PR DESCRIPTION
## Summary

Delelte `sort` argument in `exchange asset list` command

## GUS Ticket

[W-10717188](https://gus.lightning.force.com/a07EE00000pS8V8YAK)
