### PR TITLE
W-11094553-fix-order-of-commands-fa

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -2,7 +2,7 @@
 * xref:index.adoc[Anypoint CLI 3.x]
 * xref:intro.adoc[]
 * xref:anypoint-platform-cli-commands.adoc[List of Commands]
-* xref:account.adoc[Anypoint Platform Accounts]
+* xref:account.adoc[Anypoint Platform Account]
 * xref:env-business-groups.adoc[Environments and Business Groups]
 * xref:api-governance.adoc[API Governance]
 * xref:api-mgr.adoc[API Manager]

--- a/modules/ROOT/pages/anypoint-platform-cli-commands.adoc
+++ b/modules/ROOT/pages/anypoint-platform-cli-commands.adoc
@@ -11,9 +11,9 @@ Anypoint Platform CLI provides the ability to manage these features in Anypoint 
 * <<cloudhub-apps>>
 * <<cloudhub-dlb>>
 * <<cloudhub-vpc>>
-* <<design-center>>
 * <<datagraph-load-balancers>>
 * <<datagraph-source>>
+* <<design-center>>
 * <<exchange-assets>>
 * <<standalone-apps>>
 * <<standalone-alerts>>


### PR DESCRIPTION
Fixed alphabetic order of the list (with the exception of Environments and Business Groups, which are used to change environments in interactive mode and should be on top).
Remove the s from Anypoint Platform Accounts