### PR TITLE
Update api-mgr.adoc

### DIFF
--- a/modules/ROOT/pages/_partials/api-mgr.adoc
+++ b/modules/ROOT/pages/_partials/api-mgr.adoc
@@ -97,7 +97,7 @@ You can pass this option multiple times to specify multiple emails.
 | Response codes to trigger `response-code` alert type. +
 You can pass this option multiple times to specify multiple codes.
 
-| `policyId [num]`
+| `policyInstanceId [num]`
 | ID of a policy applied to API instance to trigger `response-code` alert type.
 |===
 
@@ -558,10 +558,10 @@ Supported values are `table` (default) and `json`
 == api-mgr:policy:disable
 
 ----
-> api-mgr:policy:disable [options] <apiInstanceId> <policyId>
+> api-mgr:policy:disable [options] <apiInstanceId> <policyInstanceId>
 ----
 
-This command disables the policy passed in `<policyId>` from the API instance passed in `<apiInstanceId>`.
+This command disables the policy passed in `<policyInstanceId>` from the API instance passed in `<apiInstanceId>`.
 
 This command accepts only the default option `--help`.
 
@@ -569,10 +569,10 @@ This command accepts only the default option `--help`.
 == api-mgr:policy:edit
 
 ----
-> api-mgr:policy:edit [options] <apiInstanceId> <policyId>
+> api-mgr:policy:edit [options] <apiInstanceId> <policyInstanceId>
 ----
 
-This command edits the policy configuration passed in `<policyId>` of the API Instance passed in `<apiInstanceId>`.
+This command edits the policy configuration passed in `<policyInstanceId>` of the API Instance passed in `<apiInstanceId>`.
 
 Besides the default `--help` option, this command also accepts:
 
@@ -592,10 +592,10 @@ For example `api-mgr:policy:apply (...) -p '[{"methodRegex":"GET|PUT","uriTempla
 == api-mgr:policy:enable
 
 ----
-> api-mgr:policy:enable [options] <apiInstanceId> <policyId>
+> api-mgr:policy:enable [options] <apiInstanceId> <policyInstanceId>
 ----
 
-This command enables the policy passed in `<policyId>` for the API Instance passed in `<apiInstanceId>`.
+This command enables the policy passed in `<policyInstanceId>` for the API Instance passed in `<apiInstanceId>`.
 
 This command accepts only the default option `--help`.
 
@@ -615,10 +615,10 @@ Besides the default `--help` option, this command also accepts the `-m, --muleVe
 == api-mgr:policy:remove
 
 ----
-> api-mgr:policy:remove [options] <apiInstanceId> <policyId>
+> api-mgr:policy:remove [options] <apiInstanceId> <policyInstanceId>
 ----
 
-This command removes the policy specified in `<policyId>` from the API instance passed in `<apiInstanceId>`.
+This command removes the policy specified in `<policyInstanceId>` from the API instance passed in `<apiInstanceId>`.
 
 This command accepts only the default option `--help`.
 


### PR DESCRIPTION
Changed the name of some policyId entries to reflect a difference between policyId in reference to the name of a policy and policyId in reference to instances of the policy applied to an instance of an API